### PR TITLE
Update Metro config to avoid live-reloading client when server DB changes

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,7 +1,11 @@
+const exclusionList = require('metro-config/src/defaults/exclusionList');
+
 const { getDefaultConfig } = require("expo/metro-config");
 
 const defaultConfig = getDefaultConfig(__dirname);
 
 defaultConfig.resolver.assetExts.push("db");
+
+defaultConfig.resolver.blockList = exclusionList([/server\/dbs\/.*/])
 
 module.exports = defaultConfig;


### PR DESCRIPTION
Default metro config was tweaked to allow bundling of **.db** files, so the client DB would get bundled. This was also picking up the server **.db** file, so added an exclusion to that file path. Hence, the blue "refreshing" toast at the top of the screen on every transaction.

With a little rearranging, this rule could prevent the bundler from looking at the whole server folder. Right now the client uses **server/mutators.ts**, so didn't want to mess around with it. Since **server** folder is pretty small, can't say it would be a big deal performance-wise either way.