### PR TITLE
Get experimental sync working on Android emulator

### DIFF
--- a/ExperimentalPrismaProvider.tsx
+++ b/ExperimentalPrismaProvider.tsx
@@ -3,7 +3,7 @@ import '@prisma/client/react-native';
 import { PrismaClient } from '@prisma/client/react-native';
 import { reactiveHooksExtension } from "@prisma/react-native";
 import { BaseMutators } from './server/BaseMutators';
-import { LogBox } from 'react-native';
+import { LogBox, Platform } from 'react-native';
 LogBox.ignoreLogs(["warn(prisma-client) This is the 10th instance of Prisma Client being started. Make sure this is intentional."])
 
 export interface PrismaProviderProps {
@@ -168,7 +168,7 @@ export function createPrismaProvider<T extends BaseMutators>(mutatorClass: (new 
 
 
                     // setup sync mechanism
-                    const ws = new WebSocket('ws://localhost:8080');
+                    const ws = new WebSocket(`ws://${Platform.OS === 'android' ? '10.0.2.2' : 'localhost'}:8080`);
                     ws.onopen = () => {
                         console.log('Connected to server');
 
@@ -186,6 +186,10 @@ export function createPrismaProvider<T extends BaseMutators>(mutatorClass: (new 
 
                     ws.onclose = () => {
                         console.log('Disconnected from server');
+                    }
+
+                    ws.onerror = (e) => {
+                        console.log(e);
                     }
 
 


### PR DESCRIPTION
Android emulators use a special IP address to loop back to localhost. Added a conditional to use that instead, and I had sync working back and forth between Android and iOS emulators.

This will only work for emulators/ simulators. It'd be cool to make it work on devices, too. [Expo environment variables](https://docs.expo.dev/guides/environment-variables/) combined with [emulator detection in `expo-device`](https://docs.expo.dev/versions/latest/sdk/device/#deviceisdevice) could be a lightweight way to do this, optionally piping in an IP address that's used for devices on the local network only. I might try to set this up if I have time.